### PR TITLE
Removed JDK 8 from build path in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,6 @@
 */
 buildPlugin(useContainerAgent: true,
     configurations: [
-    [platform: 'linux', jdk: '8'],
     [platform: 'linux', jdk: '11'],
-    [platform: 'windows', jdk: '8'],
     [platform: 'windows', jdk: '11']
 ])


### PR DESCRIPTION
Removed JDK 8 from build path in Jenkinsfile
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
